### PR TITLE
記事とコメントのテストデータ作成/一覧画面にコメント件数表示

### DIFF
--- a/app/Article.php
+++ b/app/Article.php
@@ -15,5 +15,10 @@ class Article extends Model
         return $this->belongsTo('App\User');
     }
 
+    public function comments()
+    {
+        return $this->hasMany('App\Comment');
+    }
+
 
 }

--- a/app/Comment.php
+++ b/app/Comment.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    protected $fillable = [
+        'body',
+    ];
+
+    public function article()
+    {
+        return $this->belongsTo('App\Article');
+    }
+}

--- a/database/factories/ArticleFactory.php
+++ b/database/factories/ArticleFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Article;
+use Faker\Generator as Faker;
+
+$factory->define(Article::class, function (Faker $faker) {
+    return [
+        'message_text' => "本文です。テキストテキストテキストテキスト",
+    ];
+});

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Comment;
+use Faker\Generator as Faker;
+
+$factory->define(Comment::class, function (Faker $faker) {
+    return [
+        'body' => "コメントです。テキストテキストテキストテキストテキストテキスト。\nテキストテキスト",
+    ];
+});

--- a/database/migrations/2020_02_20_111527_create_comments_table.php
+++ b/database/migrations/2020_02_20_111527_create_comments_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->Integer('article_id')->unsigned();
+            $table->text('body');
+            $table->timestamps();
+            //外部キーの設定
+            $table->foreign('article_id')->references('id')->on('articles');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/database/seeds/ArticlesTableSeeder.php
+++ b/database/seeds/ArticlesTableSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Comment;
+use App\Article;
+
+class ArticlesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(Article::class, 2)
+        ->create()
+        ->each(function ($article) {
+            $comments = factory(App\Comment::class, 2)->make();
+            $article->comments()->saveMany($comments);
+        });
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use App\Comment;
+use App\Article;
 
 class DatabaseSeeder extends Seeder
 {
@@ -12,5 +14,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // $this->call(UsersTableSeeder::class);
+        $this->call(ArticlesTableSeeder::class);
     }
 }

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -108,6 +108,11 @@
                 {{ $one_article->user->name}}
                 <span class="created-at">{{ $one_article->created_at }}</span>
                 <p>{{ $one_article->message_text }}</p>
+                @if ($one_article->comments->count())
+                    <span class="badge badge-primary">
+                        コメント {{ $one_article->comments->count() }}件
+                    </span>
+                @endif
             </div>
         </div>
         @endforeach


### PR DESCRIPTION
新しいコメントテーブルを用意し、ファクトリとシーダでテストデータ作成
記事2件にそれぞれコメント2件ずつ作成
それをindex.blade.phpの投稿一覧画面に「コメント件数」として表示。